### PR TITLE
feat(bluefin-extra): add leaf-collector, duality, and eyes wallpapers…

### DIFF
--- a/.github/workflows/bluefin-wallpapers-extra.yaml
+++ b/.github/workflows/bluefin-wallpapers-extra.yaml
@@ -30,8 +30,8 @@ jobs:
           mkdir -p output/packaging/gnome/images
           mkdir -p output/packaging/png
           
-          # Process all extra wallpapers: collapse, dusk, prey, tenacious-pterosaur
-          for wp in "dusk" "prey" "huntress" "tenacious-pterosaur"; do
+          # Process all extra wallpapers
+          for wp in "dusk" "prey" "huntress" "tenacious-pterosaur" "leaf-collector" "duality" "eyes"; do
             # macOS: HEIC dynamic wallpapers
             cp wallpapers/$wp/macos/*.heic output/packaging/macos/ 2>/dev/null || true
             

--- a/wallpapers/eyes/gnome/gnome-background-properties/eyes.xml
+++ b/wallpapers/eyes/gnome/gnome-background-properties/eyes.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<!DOCTYPE wallpapers SYSTEM "gnome-wp-list.dtd">
+<wallpapers>
+  <wallpaper deleted="false">
+    <name>Project Bluefin - Eyes</name>
+    <filename>~/.local/share/backgrounds/bluefin/eyes/eyes.svg</filename>
+    <options>zoom</options>
+  </wallpaper>
+</wallpapers>


### PR DESCRIPTION
… to release

Add three wallpapers to the bluefin-wallpapers-extra packaging workflow:
- leaf-collector (day/night SVG + existing GNOME XML)
- duality (day/night SVG + existing GNOME XML)
- eyes (single SVG + new GNOME XML)

Create wallpapers/eyes/gnome/gnome-background-properties/eyes.xml since eyes has only a single SVG (both day and night point to the same file).

The existing || true fallbacks handle missing KDE (.avif) and macOS (.heic) assets gracefully — these three wallpapers are SVG-only.

Closes castrojo/artwork#1


Assisted-by: Claude Sonnet 4.6 via GitHub Copilot